### PR TITLE
任意のジオコーディングライブラリを使用できるように修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,5 @@
 # Leaflet.CommunityGeoCoder
 
-株式会社 Geolonia 様の[オープンソース住所正規化ライブラリ](https://github.com/geolonia/normalize-japanese-addresses)を活用し、
 Leaflet.js 地図に住所検索機能を追加するプラグインです。  
 検索窓に日本国内の住所を入力するとその場所に地図が遷移します。
 
@@ -11,48 +10,72 @@ Leaflet.js 地図に住所検索機能を追加するプラグインです。
 ![demo page](https://i.imgur.com/7oXSJMr.png)
 
 住所を入力してボタンを押すと、地図がその場所まで遷移します。
-町名まで入れていただくとかなりピンポイントな地点まで移動します。
-是非デモページを触って、株式会社 Geolonia 様の高性能なジオコーディングをお試しください！
+町名まで入れていただくと、かなりピンポイントな地点まで移動します。  
+
+なおこちらのサンプルでは、株式会社 Geolonia さんの[オープンソース住所正規化ライブラリ](https://github.com/geolonia/normalize-japanese-addresses)を使用しています。サンプルを触っていただき気に入っていただけましたら、Geoloniaさんの製品もぜひチェックしていただければと思います。
 
 ## Usage
 
-Leaflet 1.x 系に対応しています。
-
-### From CDN (Recommended)
-
-本プラグインは CDN からも利用可能です。サンプルコードは[こちら](https://cocon.github.io/Leaflet.CommunityGeoCoder/demo/)にございます。
-
-```terminal
-https://cdn.jsdelivr.net/npm/@coconmap/leaflet.communitygeocoder/dist/bundle.js
-```
-
-### From NPM (Experimental)
+Leaflet.CommunityGeocoder単体では住所の検索はできません。  
+別途、住所正規化のライブラリをインストールしていただく必要があります。  
+ここでは株式会社 Geolonia さんの`@geolonia/normalize-japanese-addresses`を用いたコードサンプルをご紹介します。
 
 ```bash
 npm install @coconmap/leaflet.communitygeocoder
+npm install @geolonia/normalize-japanese-addresses
 ```
-
-#### Basic usage
 
 ```typescript
 import L from "leaflet";
 import { GeoCoder } from "@coconmap/leaflet.communitygeocoder";
+import { normalize } from "@geolonia/normalize-japanese-addresses";
 
-const map = new L.map("map");
-const geoCoderControl = new GeoCoder();
+const map = new L.Map("map", {
+    center: [35.4477712, 139.6425415],
+    zoom: 13
+});
+L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+}).addTo(map);
+
+const geoCoderControl = new GeoCoder(normalize);
 geoCoderControl.addTo(map);
 ```
 
-#### Without control
+また、検索フォームはいらない、という場合にはsearchメソッドのみを使うことができます。  
+なおこの場合、searchメソッドを呼び出す前にonメソッドを使ってGeoCoderとLeaflet地図を関連づけておく必要があるので注意してください。
 
 ```typescript
-import L from "leaflet";
-import { GeoCoder } from "@coconmap/leaflet.communitygeocoder";
-
-const map = new L.map("map");
-const geoCoder = GeoCoder.on(map);
-geoCoder("東京都千代田区霞が関1-3-1");
+const geoCoder = new GeoCoder(normalize);
+geoCoder.on(map);
+geoCoder.search("東京都千代田区霞が関1-3-1");
 ```
+
+また、バンドラーを使わない場合はJsDelivrなどのCDNをご利用いただけます。
+
+```text
+https://cdn.jsdelivr.net/npm/@coconmap/leaflet.communitygeocoder/dist/bundle.js
+```
+
+## Development
+
+GeoCoderクラスのコンストラクタ引数である、Normalizerの定義は次のようになっています。
+
+```typescript
+type Normalizer = (address: string, options?: any) => Promise<NormalizeResult>
+interface NormalizeResult {
+ lat: number | null,
+ lng: number | null,
+ pref: string,
+ city: string,
+ town: string,
+ addr: string,
+ level: number
+}
+```
+
+この定義に準拠していさえすればどのようなライブラリでもお使いいただくことができます。  
+もしこのような正規化ライブラリを開発中の方がおられましたら、Issue等で連絡いただけますと光栄です。
 
 ## Author
 

--- a/demo/index.html
+++ b/demo/index.html
@@ -10,6 +10,7 @@
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/leaflet@1.8.0/dist/leaflet.css">
 	<script src="https://cdn.jsdelivr.net/npm/leaflet@1.8.0/dist/leaflet.js"></script>
 	<script src="https://cdn.jsdelivr.net/npm/@coconmap/leaflet.communitygeocoder/dist/bundle.js"></script>
+	<script src="https://cdn.jsdelivr.net/npm/@geolonia/normalize-japanese-addresses@2.7.2/dist/main-browser.min.js"></script>
 	<script src="https://cdn.jsdelivr.net/gh/google/code-prettify@master/loader/run_prettify.js"></script>
 	<style>
 		#my_map {

--- a/demo/main.js
+++ b/demo/main.js
@@ -1,9 +1,9 @@
 const map = new L.map("my_map", {
-	center: [35.4477712, 139.6425415],
-	zoom: 13
+    center: [35.4477712, 139.6425415],
+    zoom: 13
 });
 L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
-	attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+    attribution: '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors'
 }).addTo(map);
-const geoCoderControl = new GeoCoder();
+const geoCoderControl = new GeoCoder(normalize.normalize);
 geoCoderControl.addTo(map);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coconmap/leaflet.communitygeocoder",
-  "version": "1.0.1",
+  "version": "2.0.0-alpha.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coconmap/leaflet.communitygeocoder",
-      "version": "1.0.1",
+      "version": "2.0.0-alpha.0",
       "license": "MIT",
       "devDependencies": {
         "@types/leaflet": "^1.7.9",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "@coconmap/leaflet.communitygeocoder",
       "version": "1.0.1",
       "license": "MIT",
-      "dependencies": {
-        "@geolonia/normalize-japanese-addresses": "2.5.8"
-      },
       "devDependencies": {
         "@types/leaflet": "^1.7.9",
         "jest": "^28.0.3",
@@ -593,21 +590,6 @@
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
-      }
-    },
-    "node_modules/@geolonia/japanese-numeral": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/@geolonia/japanese-numeral/-/japanese-numeral-0.1.16.tgz",
-      "integrity": "sha512-xzSsIHhyyjqNpW8qSh5bFMu3FJvyJGBbNZ/t8clPHkigjUdZ7Ck8wkzCkcwlVd00RkoHwGDLnvXx5W0WiGK0TQ=="
-    },
-    "node_modules/@geolonia/normalize-japanese-addresses": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@geolonia/normalize-japanese-addresses/-/normalize-japanese-addresses-2.5.8.tgz",
-      "integrity": "sha512-mv3+vHU2qXPjn2wbZH2p8kOKp7zTdcwCAWz8yryyyM5OGCRjHiqGBg+1t78Ut8b0wopyLJ7GjNanIoflEEKVeg==",
-      "dependencies": {
-        "@geolonia/japanese-numeral": "^0.1.16",
-        "isomorphic-unfetch": "^3.1.0",
-        "lru-cache": "^6.0.0"
       }
     },
     "node_modules/@istanbuljs/load-nyc-config": {
@@ -2473,15 +2455,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/isomorphic-unfetch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
-      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
-      "dependencies": {
-        "node-fetch": "^2.6.1",
-        "unfetch": "^4.2.0"
-      }
-    },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
@@ -3316,6 +3289,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -3431,44 +3405,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
-    },
-    "node_modules/node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "dependencies": {
-        "whatwg-url": "^5.0.0"
-      },
-      "engines": {
-        "node": "4.x || >=6.0.0"
-      },
-      "peerDependencies": {
-        "encoding": "^0.1.0"
-      },
-      "peerDependenciesMeta": {
-        "encoding": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/node-fetch/node_modules/tr46": {
-      "version": "0.0.3",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-      "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-    },
-    "node_modules/node-fetch/node_modules/webidl-conversions": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-      "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-    },
-    "node_modules/node-fetch/node_modules/whatwg-url": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-      "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-      "dependencies": {
-        "tr46": "~0.0.3",
-        "webidl-conversions": "^3.0.0"
-      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -4332,11 +4268,6 @@
         "node": ">=4.2.0"
       }
     },
-    "node_modules/unfetch": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
-      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
-    },
     "node_modules/uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -4578,7 +4509,8 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/yargs": {
       "version": "17.4.1",
@@ -5067,21 +4999,6 @@
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.5.tgz",
       "integrity": "sha512-6nFkfkmSeV/rqSaS4oWHgmpnYw194f6hmWF5is6b0J1naJZoiD0NTc9AiUwPHvWsowkjuHErCZT1wa0jg+BLIA==",
       "dev": true
-    },
-    "@geolonia/japanese-numeral": {
-      "version": "0.1.16",
-      "resolved": "https://registry.npmjs.org/@geolonia/japanese-numeral/-/japanese-numeral-0.1.16.tgz",
-      "integrity": "sha512-xzSsIHhyyjqNpW8qSh5bFMu3FJvyJGBbNZ/t8clPHkigjUdZ7Ck8wkzCkcwlVd00RkoHwGDLnvXx5W0WiGK0TQ=="
-    },
-    "@geolonia/normalize-japanese-addresses": {
-      "version": "2.5.8",
-      "resolved": "https://registry.npmjs.org/@geolonia/normalize-japanese-addresses/-/normalize-japanese-addresses-2.5.8.tgz",
-      "integrity": "sha512-mv3+vHU2qXPjn2wbZH2p8kOKp7zTdcwCAWz8yryyyM5OGCRjHiqGBg+1t78Ut8b0wopyLJ7GjNanIoflEEKVeg==",
-      "requires": {
-        "@geolonia/japanese-numeral": "^0.1.16",
-        "isomorphic-unfetch": "^3.1.0",
-        "lru-cache": "^6.0.0"
-      }
     },
     "@istanbuljs/load-nyc-config": {
       "version": "1.1.0",
@@ -6578,15 +6495,6 @@
       "integrity": "sha1-TkMekrEalzFjaqH5yNHMvP2reN8=",
       "dev": true
     },
-    "isomorphic-unfetch": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/isomorphic-unfetch/-/isomorphic-unfetch-3.1.0.tgz",
-      "integrity": "sha512-geDJjpoZ8N0kWexiwkX8F9NkTsXhetLPVbZFQ+JTW239QNOwvB0gniuR1Wc6f0AMTn7/mFGyXvHTifrCp/GH8Q==",
-      "requires": {
-        "node-fetch": "^2.6.1",
-        "unfetch": "^4.2.0"
-      }
-    },
     "istanbul-lib-coverage": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.0.tgz",
@@ -7229,6 +7137,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "requires": {
         "yallist": "^4.0.0"
       }
@@ -7320,35 +7229,6 @@
       "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.2.tgz",
       "integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
       "dev": true
-    },
-    "node-fetch": {
-      "version": "2.6.7",
-      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-      "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
-      "requires": {
-        "whatwg-url": "^5.0.0"
-      },
-      "dependencies": {
-        "tr46": {
-          "version": "0.0.3",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
-          "integrity": "sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o="
-        },
-        "webidl-conversions": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
-          "integrity": "sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE="
-        },
-        "whatwg-url": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
-          "integrity": "sha1-lmRU6HZUYuN2RNNib2dCzotwll0=",
-          "requires": {
-            "tr46": "~0.0.3",
-            "webidl-conversions": "^3.0.0"
-          }
-        }
-      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -7940,11 +7820,6 @@
       "integrity": "sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==",
       "dev": true
     },
-    "unfetch": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/unfetch/-/unfetch-4.2.0.tgz",
-      "integrity": "sha512-F9p7yYCn6cIW9El1zi0HI6vqpeIvBsr3dSuRO6Xuppb1u5rXpCPmMvLSyECLhybr9isec8Ohl0hPekMVrEinDA=="
-    },
     "uri-js": {
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.4.1.tgz",
@@ -8117,7 +7992,8 @@
     "yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "yargs": {
       "version": "17.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@coconmap/leaflet.communitygeocoder",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@coconmap/leaflet.communitygeocoder",
-      "version": "2.0.0-alpha.0",
+      "version": "2.0.0",
       "license": "MIT",
       "devDependencies": {
         "@types/leaflet": "^1.7.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coconmap/leaflet.communitygeocoder",
-  "version": "1.0.1",
+  "version": "2.0.0-alpha.0",
   "description": "Leaflet.js plugin for geocoding addressed of Japan",
   "main": "dist/index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
   },
   "keywords": [
     "geocoding",
-    "leaflet-plugin"
+    "leaflet-plugin",
+    "geolonia"
   ],
   "author": "YUUKIToriyama <github@toriyama.dev>",
   "license": "MIT",
@@ -33,8 +34,5 @@
     "typescript": "^4.6.4",
     "webpack": "^5.72.0",
     "webpack-cli": "^4.9.2"
-  },
-  "dependencies": {
-    "@geolonia/normalize-japanese-addresses": "2.5.8"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@coconmap/leaflet.communitygeocoder",
-  "version": "2.0.0-alpha.0",
+  "version": "2.0.0",
   "description": "Leaflet.js plugin for geocoding addressed of Japan",
   "main": "dist/index.js",
   "scripts": {

--- a/src/GeoCoder.ts
+++ b/src/GeoCoder.ts
@@ -1,11 +1,22 @@
 import L from 'leaflet';
-import * as Geolonia from '@geolonia/normalize-japanese-addresses';
 
-import PopupContent from './PopupContent';
 import Control from './Control';
+import PopupContent from './PopupContent';
+
+interface ParsedAddress { pref: string, city: string, town: string }
+type Normalizer = (address: string, options?: any) => Promise<NormalizeResult>
+interface NormalizeResult {
+	lat: number | null,
+	lng: number | null,
+	pref: string,
+	city: string,
+	town: string,
+	addr: string,
+	level: number
+}
 
 class Utils {
-	static createPin = (map: L.Map, latlng: L.LatLng, data: { pref: string, city: string, town: string }) => {
+	static createPin = (map: L.Map, latlng: L.LatLng, data: ParsedAddress) => {
 		const marker = L.marker(latlng, {
 			alt: `${data.pref} ${data.city} ${data.town}`
 		});
@@ -26,63 +37,66 @@ class Utils {
 	};
 };
 
-type GeoCoderWithoutControl = (address: string) => Promise<Geolonia.NormalizeResult>;
-
 export class GeoCoder extends L.Control {
 	_div: HTMLElement | undefined;
-	constructor(options?: L.ControlOptions) {
+	private normalizer: Normalizer;
+	private map: L.Map | undefined;
+	constructor(normalizer: Normalizer, options?: L.ControlOptions) {
 		super(options);
+		this.normalizer = normalizer
 	}
 
-	onAdd = (map: L.Map) => {
+	override onAdd = (map: L.Map) => {
+		this.map = map;
 		this._div = L.DomUtil.create("div", "leaflet-community-geocoder");
-		this._div.appendChild(new Control(GeoCoder.on(map)));
+		this._div.appendChild(new Control(this.search));
 		return this._div;
 	}
 
-	static on = (map: L.Map): GeoCoderWithoutControl => {
-		// 関数を返す
-		return async (address: string) => {
-			const result = await Geolonia.normalize(address);
-			if (result.level >= 3) {
-				// level 3 まで判別できた場合には、緯度経度情報も返ってくる
-				// https://github.com/geolonia/normalize-japanese-addresses/pull/113
-				const latlng = L.latLng({
-					lat: result.lat || 35,
-					lng: result.lng || 135
-				});
-				Utils.moveTo(map, latlng);
-				Utils.createPin(map, latlng, {
-					pref: result.pref,
-					city: result.city,
-					town: result.town
-				});
-			} else if (result.level == 2) {
-				// level 2 までしか判別できなかった場合は、
-				// 別途データベースに問い合わせ、大まかな位置情報を取得する
-				const url = `https://geolonia.github.io/japanese-addresses/api/ja/${result.pref}/${result.city}.json`;
-				fetch(url).then(response => response.json()).then(json => {
-					const destination = json[0] as {
-						town: string
-						koaza: string
-						lat: string
-						lng: string
-					};
-					const latlng = L.latLng({
-						lat: parseFloat(destination.lat),
-						lng: parseFloat(destination.lng)
-					});
-					Utils.moveTo(map, latlng);
-					Utils.createPin(map, latlng, {
-						pref: result.pref,
-						city: result.city,
-						town: destination.town + destination.koaza
-					});
-				});
-			} else {
-				alert("もう少し詳しい住所を入力してください");
+	on = (map: L.Map) => {
+		this.map = map
+	}
+
+	search = async (address: string) => {
+		if (this.map == undefined) {
+			throw Error("searchメソッドを呼ぶ前に、GeoCoderをL.Mapオブジェクトと関連付ける必要があります")
+		} else {
+			try {
+				const result = await this.normalizeAddress(address)
+				Utils.moveTo(this.map, result.latlng)
+				Utils.createPin(this.map, result.latlng, result.parsedAddress)
+			} catch (error) {
+				alert(error)
 			}
-			return result;
+		}
+	}
+
+	private normalizeAddress = async (address: string): Promise<{ latlng: L.LatLng, parsedAddress: ParsedAddress }> => {
+		const result = await this.normalizer(address);
+		if (result.level >= 3) {
+			// level 3 まで判別できた場合には、緯度経度情報も返ってくる
+			// https://github.com/geolonia/normalize-japanese-addresses/pull/113
+			return {
+				latlng: L.latLng({ lat: result.lat as number, lng: result.lng as number }),
+				parsedAddress: { pref: result.pref, city: result.city, town: result.town }
+			}
+		} else if (result.level == 2) {
+			// level 2 までしか判別できなかった場合は、
+			// 別途データベースに問い合わせ、大まかな位置情報を取得する
+			const url = `https://geolonia.github.io/japanese-addresses/api/ja/${result.pref}/${result.city}.json`;
+			const json = await fetch(url).then(response => response.json())
+			const destination = json[0] as {
+				town: string
+				koaza: string
+				lat: string
+				lng: string
+			};
+			return {
+				latlng: L.latLng({ lat: parseFloat(destination.lat), lng: parseFloat(destination.lng) }),
+				parsedAddress: { pref: result.pref, city: result.city, town: result.town }
+			}
+		} else {
+			throw Error("もう少し詳しい住所を入力してください");
 		}
 	}
 }

--- a/src/GeoCoder.ts
+++ b/src/GeoCoder.ts
@@ -16,6 +16,9 @@ interface NormalizeResult {
 }
 
 class Utils {
+	/**
+	 * 引数で指定した位置にピンをポップアップマーカーを立てる
+	 */
 	static createPin = (map: L.Map, latlng: L.LatLng, data: ParsedAddress) => {
 		const marker = L.marker(latlng, {
 			alt: `${data.pref} ${data.city} ${data.town}`
@@ -32,6 +35,9 @@ class Utils {
 		marker.addTo(map); // markerをmapに追加
 		marker.openPopup(); // popupを開く 
 	}
+	/**
+	 * 引数で指定した位置に地図の中心を移動する
+	 */
 	static moveTo = (map: L.Map, location: L.LatLng) => {
 		map.flyTo(location);
 	};
@@ -41,6 +47,7 @@ export class GeoCoder extends L.Control {
 	_div: HTMLElement | undefined;
 	private normalizer: Normalizer;
 	private map: L.Map | undefined;
+
 	constructor(normalizer: Normalizer, options?: L.ControlOptions) {
 		super(options);
 		this.normalizer = normalizer
@@ -53,10 +60,17 @@ export class GeoCoder extends L.Control {
 		return this._div;
 	}
 
+	/** 
+	 * Leaflet地図とGeoCoderを関連付けます
+	 */
 	on = (map: L.Map) => {
 		this.map = map
 	}
 
+	/**
+	 * 引数に指定した住所周辺の地図を表示します
+	 * @param address 住所
+	 */
 	search = async (address: string) => {
 		if (this.map == undefined) {
 			throw Error("searchメソッドを呼ぶ前に、GeoCoderをL.Mapオブジェクトと関連付ける必要があります")
@@ -71,6 +85,9 @@ export class GeoCoder extends L.Control {
 		}
 	}
 
+	/**
+	 * コンストラクタで指定した住所パーサーと、@geolonia/japanese-addressesのデータを利用してジオコーディングを行ないます
+	 */
 	private normalizeAddress = async (address: string): Promise<{ latlng: L.LatLng, parsedAddress: ParsedAddress }> => {
 		const result = await this.normalizer(address);
 		if (result.level >= 3) {


### PR DESCRIPTION
# PR概要
- @geolonia/normalize-japanese-addressesをバンドルするのをやめ、コンストラクタ経由で動的リンクしてもらう方針に変更

# 背景
- NJAの活発な開発の成果を取り込むことができなくなっていた
- 独自にカスタムしたNJA、あるいは過去のバージョンのNJAを使えるようにしたい

# TODO
- [x] fix README.md
- [x] npm version major
- [x] npm publish